### PR TITLE
Fix crash error

### DIFF
--- a/03-the-core-data-stack/projects/final/DogWalk/DogWalk/ViewController.swift
+++ b/03-the-core-data-stack/projects/final/DogWalk/DogWalk/ViewController.swift
@@ -135,7 +135,7 @@ extension ViewController: UITableViewDataSource {
       return
     }
 
-    coreDataStack.managedContext.delete(walkToRemove)
+    currentDog?.removeFromWalks(walkToRemove)
     coreDataStack.saveContext()
     tableView.deleteRows(at: [indexPath], with: .automatic)
   }


### PR DESCRIPTION
Previously the app was crashing with NSInternalInconsistencyException when trying to delete UITableView row. Seems with this approach everything works fine